### PR TITLE
fix(sync): handle pyicloud byte download payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+.DS_Store
 __pycache__/
 *.py[cod]
 .pytest_cache/

--- a/icloud_photo_backup/sync.py
+++ b/icloud_photo_backup/sync.py
@@ -99,6 +99,10 @@ def stream_to_file(response: Any, output_path: Path) -> int:
     """Write downloaded response to file and return bytes written."""
     written = 0
     with output_path.open("wb") as fh:
+        if isinstance(response, (bytes, bytearray)):
+            fh.write(response)
+            return len(response)
+
         if hasattr(response, "iter_content"):
             for chunk in response.iter_content(chunk_size=1024 * 1024):
                 if not chunk:
@@ -121,6 +125,14 @@ def stream_to_file(response: Any, output_path: Path) -> int:
             fh.write(content)
             return len(content)
 
+        if hasattr(response, "read"):
+            content = response.read()
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            if content:
+                fh.write(content)
+                return len(content)
+
     raise RuntimeError("Download response did not contain readable binary data.")
 
 
@@ -142,6 +154,8 @@ def download_asset(
     for attempt in range(1, retries + 1):
         try:
             response = asset.download()
+            if response is None:
+                raise RuntimeError("Asset returned no downloadable data.")
             bytes_written = stream_to_file(response, temp_path)
             temp_path.replace(final_path)
             return final_path, bytes_written

--- a/tests/test_icloud_sync.py
+++ b/tests/test_icloud_sync.py
@@ -1,7 +1,14 @@
 import datetime as dt
 from pathlib import Path
 
-from icloud_sync import build_output_dir, init_db, is_downloaded, mark_downloaded, unique_path
+from icloud_sync import (
+    build_output_dir,
+    init_db,
+    is_downloaded,
+    mark_downloaded,
+    stream_to_file,
+    unique_path,
+)
 
 
 def test_unique_path_returns_original_when_unused(tmp_path: Path) -> None:
@@ -49,3 +56,10 @@ def test_db_insert_and_lookup(tmp_path: Path) -> None:
         assert is_downloaded(conn, "asset-1") is True
     finally:
         conn.close()
+
+
+def test_stream_to_file_handles_bytes(tmp_path: Path) -> None:
+    output = tmp_path / "asset.bin"
+    size = stream_to_file(b"hello", output)
+    assert size == 5
+    assert output.read_bytes() == b"hello"


### PR DESCRIPTION
## Summary
- fix download handling for `pyicloud` assets that return raw `bytes` instead of response-like objects
- keep existing response streaming paths, and add support for file-like `.read()` payloads
- add a regression test covering byte payload writes in `stream_to_file`

## Verification
- `.venv/bin/python -m pytest -q`
- Result: `20 passed`