### PR TITLE
feat(sync): add live TTY progress UI during backup

### DIFF
--- a/icloud_photo_backup/sync.py
+++ b/icloud_photo_backup/sync.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import sqlite3
+import sys
 import time
 from pathlib import Path
 from typing import Any, Iterable, Optional
@@ -24,6 +25,82 @@ VIDEO_EXTENSIONS = {
     ".mpg",
     ".webm",
 }
+
+SPINNER_FRAMES = ("|", "/", "-", "\\")
+
+
+def format_bytes(num_bytes: int) -> str:
+    """Return a human-readable byte size string."""
+    if num_bytes < 1024:
+        return f"{num_bytes} B"
+
+    units = ("KB", "MB", "GB", "TB")
+    value = float(num_bytes)
+    for unit in units:
+        value /= 1024.0
+        if value < 1024.0:
+            return f"{value:.1f} {unit}"
+    return f"{value:.1f} PB"
+
+
+class LiveSyncProgress:
+    """Render a single-line live progress indicator in TTY sessions."""
+
+    def __init__(self, *, enabled: bool) -> None:
+        self.enabled = enabled and sys.stdout.isatty()
+        self._frame_index = 0
+        self._line_len = 0
+        self._started_at = time.monotonic()
+        self._last_downloaded_bytes = 0
+
+    def render(
+        self,
+        *,
+        downloaded_bytes: int,
+        photos: int,
+        videos: int,
+        skipped: int,
+        failed: int,
+    ) -> None:
+        """Render or update the live progress line."""
+        if not self.enabled:
+            return
+
+        elapsed_seconds = max(time.monotonic() - self._started_at, 0.001)
+        displayed_downloaded_bytes = max(downloaded_bytes, self._last_downloaded_bytes)
+        self._last_downloaded_bytes = displayed_downloaded_bytes
+        bytes_per_second = int(displayed_downloaded_bytes / elapsed_seconds)
+        spinner = SPINNER_FRAMES[self._frame_index % len(SPINNER_FRAMES)]
+        self._frame_index += 1
+
+        line = (
+            f"[{spinner}] Downloaded: {format_bytes(displayed_downloaded_bytes)} "
+            f"/ {photos} Photos / {videos} Videos "
+            f"| Skipped: {skipped} | Failed: {failed} "
+            f"| Rate: {format_bytes(bytes_per_second)}/s"
+        )
+        padding = " " * max(self._line_len - len(line), 0)
+        sys.stdout.write(f"\r{line}{padding}")
+        sys.stdout.flush()
+        self._line_len = len(line)
+
+    def clear_line(self) -> None:
+        """Clear active live line before standard log output."""
+        if not self.enabled or self._line_len == 0:
+            return
+
+        sys.stdout.write(f"\r{' ' * self._line_len}\r")
+        sys.stdout.flush()
+        self._line_len = 0
+
+    def finish(self) -> None:
+        """End the live renderer and move to the next line."""
+        if not self.enabled:
+            return
+        if self._line_len > 0:
+            sys.stdout.write("\n")
+            sys.stdout.flush()
+            self._line_len = 0
 
 
 def get_asset_id(asset: Any) -> Optional[str]:
@@ -217,6 +294,10 @@ def run_sync(
     skipped_count = 0
     failed_count = 0
     processed = 0
+    downloaded_bytes = 0
+    downloaded_photos = 0
+    downloaded_videos = 0
+    progress = LiveSyncProgress(enabled=not dry_run)
 
     try:
         if not dry_run:
@@ -235,12 +316,28 @@ def run_sync(
 
             if not asset_id:
                 failed_count += 1
+                progress.clear_line()
                 logger.warning("Failed: missing asset ID")
+                progress.render(
+                    downloaded_bytes=downloaded_bytes,
+                    photos=downloaded_photos,
+                    videos=downloaded_videos,
+                    skipped=skipped_count,
+                    failed=failed_count,
+                )
                 continue
 
             if not filename:
                 failed_count += 1
+                progress.clear_line()
                 logger.warning("Failed: asset %s has no filename metadata", asset_id)
+                progress.render(
+                    downloaded_bytes=downloaded_bytes,
+                    photos=downloaded_photos,
+                    videos=downloaded_videos,
+                    skipped=skipped_count,
+                    failed=failed_count,
+                )
                 continue
 
             media_type = detect_media_type(asset, filename)
@@ -248,7 +345,15 @@ def run_sync(
             if is_downloaded(conn, asset_id):
                 skipped_count += 1
                 if verbose:
+                    progress.clear_line()
                     logger.info("Skipping already downloaded: %s", filename)
+                progress.render(
+                    downloaded_bytes=downloaded_bytes,
+                    photos=downloaded_photos,
+                    videos=downloaded_videos,
+                    skipped=skipped_count,
+                    failed=failed_count,
+                )
                 continue
 
             output_dir = build_output_dir(target_dir, created_at)
@@ -271,10 +376,40 @@ def run_sync(
                     status="downloaded",
                 )
                 downloaded_count += 1
-                logger.info("Downloaded: %s", final_path)
+                downloaded_bytes += size
+                if media_type == "video":
+                    downloaded_videos += 1
+                else:
+                    downloaded_photos += 1
+                progress.render(
+                    downloaded_bytes=downloaded_bytes,
+                    photos=downloaded_photos,
+                    videos=downloaded_videos,
+                    skipped=skipped_count,
+                    failed=failed_count,
+                )
+
+                if verbose:
+                    progress.clear_line()
+                    logger.info("Downloaded file: %s", final_path)
+                    progress.render(
+                        downloaded_bytes=downloaded_bytes,
+                        photos=downloaded_photos,
+                        videos=downloaded_videos,
+                        skipped=skipped_count,
+                        failed=failed_count,
+                    )
             except Exception as exc:  # noqa: BLE001
                 failed_count += 1
+                progress.clear_line()
                 logger.error("Failed: %s (%s)", filename, exc)
+                progress.render(
+                    downloaded_bytes=downloaded_bytes,
+                    photos=downloaded_photos,
+                    videos=downloaded_videos,
+                    skipped=skipped_count,
+                    failed=failed_count,
+                )
 
         set_meta(conn, "last_sync_at", dt.datetime.now(dt.timezone.utc).isoformat())
         set_meta(conn, "last_sync_downloaded", str(downloaded_count))
@@ -282,6 +417,7 @@ def run_sync(
         set_meta(conn, "last_sync_failed", str(failed_count))
 
     finally:
+        progress.finish()
         conn.close()
 
     logger.info("\nDone.")

--- a/icloud_sync.py
+++ b/icloud_sync.py
@@ -11,6 +11,7 @@ from icloud_photo_backup.paths import build_output_dir, parse_created_at, unique
 from icloud_photo_backup.sync import (
     cleanup_stale_parts,
     download_asset,
+    format_bytes,
     get_asset_filename,
     get_asset_id,
     is_video_asset,
@@ -25,6 +26,7 @@ __all__ = [
     "cleanup_stale_parts",
     "download_asset",
     "ensure_schema",
+    "format_bytes",
     "get_asset_filename",
     "get_asset_id",
     "init_db",

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="${PROJECT_ROOT}/.venv"
+
+is_supported_python() {
+  local py_bin="$1"
+  "$py_bin" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'
+}
+
+pick_python() {
+  local candidates=(python3.12 python3.11 python3.10 python3)
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      if is_supported_python "$candidate"; then
+        echo "$candidate"
+        return 0
+      fi
+    fi
+  done
+
+  echo "No supported Python (>=3.10) found in PATH." >&2
+  echo "Install Python 3.10+ and rerun this script." >&2
+  return 1
+}
+
+PYTHON_BIN="$(pick_python)"
+
+echo "Using Python: $PYTHON_BIN"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  echo "Creating virtual environment at $VENV_DIR"
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+else
+  echo "Using existing virtual environment at $VENV_DIR"
+fi
+
+VENV_PYTHON="$VENV_DIR/bin/python"
+
+echo "Upgrading pip/setuptools/wheel"
+"$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel
+
+echo "Installing runtime dependencies"
+"$VENV_PYTHON" -m pip install -r "$PROJECT_ROOT/requirements.txt"
+
+echo "Installing project in editable mode with dev dependencies"
+"$VENV_PYTHON" -m pip install -e "$PROJECT_ROOT[dev]"
+
+echo
+echo "Install complete."
+echo "Activate with: source .venv/bin/activate"
+echo "Then run: ipb --help"

--- a/tests/test_icloud_sync.py
+++ b/tests/test_icloud_sync.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from icloud_sync import (
     build_output_dir,
+    format_bytes,
     init_db,
     is_downloaded,
     mark_downloaded,
@@ -63,3 +64,9 @@ def test_stream_to_file_handles_bytes(tmp_path: Path) -> None:
     size = stream_to_file(b"hello", output)
     assert size == 5
     assert output.read_bytes() == b"hello"
+
+
+def test_format_bytes_human_readable() -> None:
+    assert format_bytes(900) == "900 B"
+    assert format_bytes(1536) == "1.5 KB"
+    assert format_bytes(1024 * 1024) == "1.0 MB"

--- a/tests/test_sync_progress.py
+++ b/tests/test_sync_progress.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from icloud_photo_backup import sync
+
+
+class _FakeStdout:
+    def __init__(self, *, tty: bool) -> None:
+        self._tty = tty
+        self.buffer = ""
+
+    def isatty(self) -> bool:
+        return self._tty
+
+    def write(self, text: str) -> int:
+        self.buffer += text
+        return len(text)
+
+    def flush(self) -> None:
+        return None
+
+
+def test_live_progress_disabled_when_not_tty(monkeypatch) -> None:
+    fake_stdout = _FakeStdout(tty=False)
+    monkeypatch.setattr(sync.sys, "stdout", fake_stdout)
+
+    progress = sync.LiveSyncProgress(enabled=True)
+    progress.render(downloaded_bytes=1024, photos=1, videos=0, skipped=0, failed=0)
+
+    assert fake_stdout.buffer == ""
+
+
+def test_live_progress_downloaded_bytes_do_not_decrease(monkeypatch) -> None:
+    fake_stdout = _FakeStdout(tty=True)
+    monkeypatch.setattr(sync.sys, "stdout", fake_stdout)
+
+    progress = sync.LiveSyncProgress(enabled=True)
+    progress.render(downloaded_bytes=2048, photos=1, videos=0, skipped=0, failed=0)
+    progress.render(downloaded_bytes=1024, photos=1, videos=0, skipped=0, failed=0)
+
+    assert "Downloaded: 2.0 KB" in fake_stdout.buffer
+    assert "Downloaded: 1.0 KB" not in fake_stdout.buffer


### PR DESCRIPTION
## Summary
- Render a single-line live progress indicator during `ipb sync` in TTY sessions
- Shows: spinner, total bytes downloaded, photo count, video count, skipped count, failed count, transfer rate
- Gracefully degrades to silent mode when stdout is not a TTY (e.g. piped logs)
- Includes `format_bytes` helper and `LiveSyncProgress` class
- Fixes monotonic bytes display so downloaded total never visibly drops
- Add `install.sh` for one-command local setup
- 23 tests pass

## Verification
- `.venv/bin/python -m pytest -q`
- Result: `23 passed`