### PR TITLE
feat(sync): add incremental timestamp cursor for fast update scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ ipb sync
 - `ipb login` - update credentials
 - `ipb logout` - clear credentials and session files
 - `ipb status [DESTINATION]` - print config and sync status
+- `ipb cursor rebuild [DESTINATION]` - rebuild incremental cursor from existing DB rows
 
 ## Sync options
 
@@ -109,6 +110,17 @@ Tables:
 
 `downloaded_assets` uses iCloud asset ID as the primary key for deduplication.
 Rows are inserted only after successful final file write.
+
+`sync_meta` stores run metadata, including `last_downloaded_created_at`. On later
+sync runs, `ipb` uses that timestamp as an incremental cursor so it does not need
+to scan all historical assets every time.
+
+If you already have a large existing manifest and want to bootstrap/fix the cursor,
+run:
+
+```bash
+ipb cursor rebuild "/Volumes/MyExternalDrive/iCloud-backup"
+```
 
 ## Destination layout
 

--- a/icloud_photo_backup/cli.py
+++ b/icloud_photo_backup/cli.py
@@ -19,7 +19,13 @@ from .config import (
     save_config,
     set_credentials,
 )
-from .db import get_downloaded_count, get_meta, init_db
+from .db import (
+    get_downloaded_count,
+    get_latest_downloaded_created_at,
+    get_meta,
+    init_db,
+    set_meta,
+)
 from .errors import AuthError, ConfigError, StorageError
 from .paths import (
     DEFAULT_DB_NAME,
@@ -311,11 +317,15 @@ def cmd_status(args: argparse.Namespace) -> int:
     db_path = destination / db_name
 
     last_sync = None
+    last_downloaded_created_at = None
     total_downloaded = 0
     if db_path.exists():
         conn = init_db(db_path)
         try:
             last_sync = get_meta(conn, "last_sync_at")
+            last_downloaded_created_at = get_meta(conn, "last_downloaded_created_at")
+            if last_downloaded_created_at is None:
+                last_downloaded_created_at = get_latest_downloaded_created_at(conn)
             total_downloaded = get_downloaded_count(conn)
         finally:
             conn.close()
@@ -324,8 +334,42 @@ def cmd_status(args: argparse.Namespace) -> int:
     print(f"Default destination: {cfg.get('default_destination')}")
     print(f"DB path: {db_path}")
     print(f"Last sync timestamp: {last_sync}")
+    print(f"Last downloaded created_at: {last_downloaded_created_at}")
     print(f"Total downloaded count: {total_downloaded}")
     return EXIT_OK
+
+
+def cmd_cursor_rebuild(args: argparse.Namespace) -> int:
+    """Rebuild incremental cursor from existing downloaded assets."""
+    try:
+        cfg = load_config()
+    except FileNotFoundError:
+        print("Config error: config not found. Run: ipb init", file=sys.stderr)
+        return EXIT_CONFIG
+    except Exception as exc:  # noqa: BLE001
+        print(f"Config error: {exc}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    destination = resolve_destination(args.destination, cfg.get("default_destination"))
+    db_name = str(cfg.get("db_name") or DEFAULT_DB_NAME)
+    db_path = destination / db_name
+
+    if not db_path.exists():
+        print(f"Storage error: database not found at {db_path}", file=sys.stderr)
+        return EXIT_STORAGE
+
+    conn = init_db(db_path)
+    try:
+        latest_created_at = get_latest_downloaded_created_at(conn)
+        if latest_created_at is None:
+            print("No downloaded assets with created_at found; cursor not updated.")
+            return EXIT_OK
+
+        set_meta(conn, "last_downloaded_created_at", latest_created_at)
+        print(f"Rebuilt cursor: last_downloaded_created_at={latest_created_at}")
+        return EXIT_OK
+    finally:
+        conn.close()
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -363,6 +407,20 @@ def build_parser() -> argparse.ArgumentParser:
     status_parser = subparsers.add_parser("status", help="Show sync status")
     status_parser.add_argument("destination", nargs="?", type=Path, help="Destination override")
     status_parser.set_defaults(func=cmd_status)
+
+    cursor_parser = subparsers.add_parser("cursor", help="Cursor utilities")
+    cursor_sub = cursor_parser.add_subparsers(dest="cursor_command", required=True)
+    cursor_rebuild = cursor_sub.add_parser(
+        "rebuild",
+        help="Rebuild incremental cursor from database",
+    )
+    cursor_rebuild.add_argument(
+        "destination",
+        nargs="?",
+        type=Path,
+        help="Destination override",
+    )
+    cursor_rebuild.set_defaults(func=cmd_cursor_rebuild)
 
     return parser
 

--- a/icloud_photo_backup/db.py
+++ b/icloud_photo_backup/db.py
@@ -117,3 +117,17 @@ def get_downloaded_count(conn: sqlite3.Connection) -> int:
     if row is None:
         return 0
     return int(row[0])
+
+
+def get_latest_downloaded_created_at(conn: sqlite3.Connection) -> Optional[str]:
+    """Return latest non-null created_at value from downloaded assets."""
+    row = conn.execute(
+        """
+        SELECT MAX(created_at)
+        FROM downloaded_assets
+        WHERE status = 'downloaded' AND created_at IS NOT NULL
+        """
+    ).fetchone()
+    if row is None or row[0] is None:
+        return None
+    return str(row[0])

--- a/icloud_photo_backup/sync.py
+++ b/icloud_photo_backup/sync.py
@@ -9,7 +9,15 @@ from pathlib import Path
 from typing import Any, Iterable, Optional
 
 from .auth import login_icloud
-from .db import ensure_schema, init_db, is_downloaded, mark_downloaded, set_meta
+from .db import (
+    ensure_schema,
+    get_latest_downloaded_created_at,
+    get_meta,
+    init_db,
+    is_downloaded,
+    mark_downloaded,
+    set_meta,
+)
 from .logging_utils import setup_logging
 from .paths import build_output_dir, log_file_path, parse_created_at, unique_path, validate_target_dir
 
@@ -151,18 +159,57 @@ def detect_media_type(asset: Any, filename: Optional[str]) -> str:
     return "photo"
 
 
-def iter_assets(api: Any, after: Optional[dt.date], skip_videos: bool) -> Iterable[Any]:
+def parse_meta_datetime(value: Optional[str]) -> Optional[dt.datetime]:
+    """Parse ISO datetime stored in sync metadata."""
+    if not value:
+        return None
+    try:
+        return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def effective_after_datetime(
+    user_after: Optional[dt.date],
+    stored_cursor: Optional[str],
+) -> Optional[dt.datetime]:
+    """Resolve the effective lower-bound datetime for scanning assets."""
+    if user_after is not None:
+        return dt.datetime.combine(user_after, dt.time.min)
+    return parse_meta_datetime(stored_cursor)
+
+
+def album_is_descending(album: Any) -> bool:
+    """Return True when album iteration direction is descending."""
+    direction = getattr(album, "_direction", None)
+    if direction is None:
+        return False
+
+    raw_value = getattr(direction, "value", direction)
+    return str(raw_value).upper() == "DESCENDING"
+
+
+def iter_assets(
+    api: Any,
+    after: Optional[dt.datetime],
+    skip_videos: bool,
+) -> Iterable[Any]:
     """Yield assets from iCloud Photos with optional filtering."""
     photos = getattr(api, "photos", None)
     if photos is None:
         raise RuntimeError("iCloud Photos is unavailable for this account.")
 
     album = photos.all
+    descending = album_is_descending(album)
     for asset in album:
         created_at = parse_created_at(getattr(asset, "created", None))
 
         if after is not None:
-            if created_at is None or created_at.date() < after:
+            if created_at is None:
+                continue
+            if created_at < after:
+                if descending:
+                    break
                 continue
 
         filename = get_asset_filename(asset)
@@ -298,13 +345,25 @@ def run_sync(
     downloaded_photos = 0
     downloaded_videos = 0
     progress = LiveSyncProgress(enabled=not dry_run)
+    latest_created_at_downloaded: Optional[dt.datetime] = None
 
     try:
         if not dry_run:
             cleanup_stale_parts(target_dir, logger)
 
+        stored_cursor = get_meta(conn, "last_downloaded_created_at")
+        if stored_cursor is None:
+            stored_cursor = get_latest_downloaded_created_at(conn)
+
+        scan_after = effective_after_datetime(after, stored_cursor)
+        if scan_after is not None:
+            logger.info(
+                "Using incremental timestamp cursor: %s",
+                scan_after.isoformat(),
+            )
+
         logger.info("\nScanning iCloud Photos...")
-        for asset in iter_assets(api, after=after, skip_videos=skip_videos):
+        for asset in iter_assets(api, after=scan_after, skip_videos=skip_videos):
             if limit is not None and processed >= limit:
                 break
 
@@ -376,6 +435,14 @@ def run_sync(
                     status="downloaded",
                 )
                 downloaded_count += 1
+                if created_at is not None:
+                    if latest_created_at_downloaded is None:
+                        latest_created_at_downloaded = created_at
+                    else:
+                        latest_created_at_downloaded = max(
+                            latest_created_at_downloaded,
+                            created_at,
+                        )
                 downloaded_bytes += size
                 if media_type == "video":
                     downloaded_videos += 1
@@ -415,6 +482,12 @@ def run_sync(
         set_meta(conn, "last_sync_downloaded", str(downloaded_count))
         set_meta(conn, "last_sync_skipped", str(skipped_count))
         set_meta(conn, "last_sync_failed", str(failed_count))
+        if latest_created_at_downloaded is not None:
+            set_meta(
+                conn,
+                "last_downloaded_created_at",
+                latest_created_at_downloaded.isoformat(),
+            )
 
     finally:
         progress.finish()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -184,3 +184,61 @@ def test_main_routes_sync_subcommand(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(cli.sys, "argv", ["ipb", "sync", str(tmp_path), "--dry-run"])
     assert cli.main() == 0
     assert called["value"] is True
+
+
+def test_cmd_cursor_rebuild_sets_meta_from_existing_rows(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    destination = tmp_path / "dest"
+    destination.mkdir(parents=True, exist_ok=True)
+    db_path = destination / ".ipb.sqlite3"
+    conn = init_db(db_path)
+    try:
+        mark_downloaded(
+            conn,
+            asset_id="id-1",
+            filename="IMG_1.HEIC",
+            local_path=destination / "2026" / "01" / "IMG_1.HEIC",
+            created_at=dt.datetime(2026, 1, 2, 3, 4, 5),
+            file_size=20,
+            media_type="photo",
+        )
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(
+        cli,
+        "load_config",
+        lambda: {"default_destination": str(destination), "db_name": ".ipb.sqlite3"},
+    )
+    monkeypatch.setattr(
+        cli,
+        "resolve_destination",
+        lambda cli_destination, default_destination: destination,
+    )
+
+    args = argparse.Namespace(destination=None)
+    assert cli.cmd_cursor_rebuild(args) == cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "Rebuilt cursor: last_downloaded_created_at=2026-01-02T03:04:05" in out
+
+
+def test_cmd_cursor_rebuild_handles_missing_db(tmp_path: Path, monkeypatch) -> None:
+    destination = tmp_path / "dest"
+    destination.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        cli,
+        "load_config",
+        lambda: {"default_destination": str(destination), "db_name": ".ipb.sqlite3"},
+    )
+    monkeypatch.setattr(
+        cli,
+        "resolve_destination",
+        lambda cli_destination, default_destination: destination,
+    )
+
+    args = argparse.Namespace(destination=None)
+    assert cli.cmd_cursor_rebuild(args) == cli.EXIT_STORAGE

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from icloud_photo_backup.db import (
     get_downloaded_count,
+    get_latest_downloaded_created_at,
     get_meta,
     init_db,
     is_downloaded,
@@ -36,5 +37,34 @@ def test_mark_downloaded_increments_count(tmp_path: Path) -> None:
         )
         assert is_downloaded(conn, "id-1") is True
         assert get_downloaded_count(conn) == 1
+    finally:
+        conn.close()
+
+
+def test_get_latest_downloaded_created_at(tmp_path: Path) -> None:
+    conn = init_db(tmp_path / ".ipb.sqlite3")
+    try:
+        assert get_latest_downloaded_created_at(conn) is None
+        mark_downloaded(
+            conn,
+            asset_id="id-1",
+            filename="IMG_1.HEIC",
+            local_path=tmp_path / "2024" / "01" / "IMG_1.HEIC",
+            created_at=dt.datetime(2024, 1, 1, 12, 0, 0),
+            file_size=10,
+            media_type="photo",
+        )
+        mark_downloaded(
+            conn,
+            asset_id="id-2",
+            filename="IMG_2.HEIC",
+            local_path=tmp_path / "2024" / "01" / "IMG_2.HEIC",
+            created_at=dt.datetime(2024, 2, 1, 12, 0, 0),
+            file_size=10,
+            media_type="photo",
+        )
+        latest = get_latest_downloaded_created_at(conn)
+        assert latest is not None
+        assert latest.startswith("2024-02-01T12:00:00")
     finally:
         conn.close()

--- a/tests/test_sync_progress.py
+++ b/tests/test_sync_progress.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datetime as dt
+
 from icloud_photo_backup import sync
 
 
@@ -39,3 +41,81 @@ def test_live_progress_downloaded_bytes_do_not_decrease(monkeypatch) -> None:
 
     assert "Downloaded: 2.0 KB" in fake_stdout.buffer
     assert "Downloaded: 1.0 KB" not in fake_stdout.buffer
+
+
+def test_effective_after_datetime_prefers_user_after_date() -> None:
+    result = sync.effective_after_datetime(
+        dt.date(2026, 3, 1),
+        "2020-01-01T00:00:00+00:00",
+    )
+    assert result == dt.datetime(2026, 3, 1, 0, 0, 0)
+
+
+def test_effective_after_datetime_uses_stored_cursor_when_no_user_after() -> None:
+    result = sync.effective_after_datetime(None, "2026-03-01T12:34:56+00:00")
+    assert result == dt.datetime(2026, 3, 1, 12, 34, 56, tzinfo=dt.timezone.utc)
+
+
+class _FakeAsset:
+    def __init__(self, created: dt.datetime, filename: str) -> None:
+        self.created = created
+        self.filename = filename
+
+
+class _FakeDirection:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+class _FakeAlbum:
+    def __init__(self, assets, direction_value: str = "ASCENDING") -> None:
+        self._assets = assets
+        self._direction = _FakeDirection(direction_value)
+
+    def __iter__(self):
+        return iter(self._assets)
+
+
+class _FakePhotos:
+    def __init__(self, album):
+        self.all = album
+
+
+class _FakeApi:
+    def __init__(self, album):
+        self.photos = _FakePhotos(album)
+
+
+def test_iter_assets_respects_after_datetime() -> None:
+    assets = [
+        _FakeAsset(dt.datetime(2026, 3, 1, 10, 0, 0), "old.jpg"),
+        _FakeAsset(dt.datetime(2026, 3, 1, 12, 0, 0), "new.jpg"),
+    ]
+    api = _FakeApi(_FakeAlbum(assets, "ASCENDING"))
+
+    result = list(
+        sync.iter_assets(
+            api,
+            after=dt.datetime(2026, 3, 1, 11, 0, 0),
+            skip_videos=False,
+        )
+    )
+    assert [asset.filename for asset in result] == ["new.jpg"]
+
+
+def test_iter_assets_breaks_early_for_descending_album() -> None:
+    assets = [
+        _FakeAsset(dt.datetime(2026, 3, 2, 9, 0, 0), "recent.jpg"),
+        _FakeAsset(dt.datetime(2026, 3, 1, 9, 0, 0), "older.jpg"),
+        _FakeAsset(dt.datetime(2026, 3, 3, 9, 0, 0), "should-not-be-reached.jpg"),
+    ]
+    api = _FakeApi(_FakeAlbum(assets, "DESCENDING"))
+
+    result = list(
+        sync.iter_assets(
+            api,
+            after=dt.datetime(2026, 3, 1, 12, 0, 0),
+            skip_videos=False,
+        )
+    )
+    assert [asset.filename for asset in result] == ["recent.jpg"]


### PR DESCRIPTION
## Summary
- Store `last_downloaded_created_at` in `sync_meta` and use it as a cursor on subsequent sync runs so only new assets are scanned
- Add `ipb cursor rebuild [DESTINATION]` to bootstrap the cursor from existing `downloaded_assets` rows
- Add `ipb status` display of `Last downloaded created_at`
- Break asset iteration early when album is descending (iCloud All Photos album) to avoid scanning history on each run
- 30 tests pass

## Verification
- `.venv/bin/python -m pytest -q`
- Result: `30 passed`