### PR TITLE
fix(sync): avoid future timestamps advancing cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project are documented in this file.
 
+## [1.2.4] - 2026-04-06
+
+### Fixed
+
+- Prevented incremental cursor updates from advancing to future `created_at` timestamps during sync runs.
+- Added a safeguard warning and kept cursor unchanged when a run only downloads assets with future timestamps.
+
+### Tests
+
+- Added regression tests for cursor behavior with future-dated assets.
+
 ## [1.2.3] - 2026-04-06
 
 ### Fixed

--- a/icloud_photo_backup/sync.py
+++ b/icloud_photo_backup/sync.py
@@ -424,6 +424,7 @@ def run_sync(
     progress = LiveSyncProgress(enabled=not dry_run)
     scan_progress = LiveScanProgress(enabled=not dry_run)
     latest_created_at_downloaded: Optional[dt.datetime] = None
+    saw_future_created_at = False
     scanned_assets = 0
     matched_assets = 0
 
@@ -539,7 +540,16 @@ def run_sync(
                 )
                 downloaded_count += 1
                 if created_at is not None:
-                    if latest_created_at_downloaded is None:
+                    now = dt.datetime.now(dt.timezone.utc)
+                    if created_at > now:
+                        saw_future_created_at = True
+                        logger.warning(
+                            "Skipping asset with future timestamp: %s > %s (%s)",
+                            created_at,
+                            now,
+                            filename,
+                        )
+                    elif latest_created_at_downloaded is None:
                         latest_created_at_downloaded = created_at
                     else:
                         latest_created_at_downloaded = max(
@@ -590,7 +600,12 @@ def run_sync(
                 conn,
                 "last_downloaded_created_at",
                 latest_created_at_downloaded.isoformat(),
-                )
+            )
+        elif downloaded_count > 0 and saw_future_created_at:
+            logger.warning(
+                "Cursor unchanged: downloaded assets included only future "
+                "created_at values in this run."
+            )
 
     finally:
         scan_progress.render(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "icloud-photo-backup"
-version = "1.2.3"
+version = "1.2.4"
 description = "Incremental iCloud Photos backup CLI for macOS"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_sync_cursor_future_dates.py
+++ b/tests/test_sync_cursor_future_dates.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+from icloud_photo_backup import sync
+from icloud_photo_backup.db import get_meta, init_db
+
+
+class _FakeLogger:
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+
+    def info(self, message: str, *args) -> None:  # noqa: ANN002
+        return None
+
+    def warning(self, message: str, *args) -> None:  # noqa: ANN002
+        self.warnings.append(message % args if args else message)
+
+    def error(self, message: str, *args) -> None:  # noqa: ANN002
+        return None
+
+
+class _FakeAsset:
+    def __init__(self, asset_id: str, filename: str, created: dt.datetime) -> None:
+        self.id = asset_id
+        self.filename = filename
+        self.created = created
+
+
+def _configure_sync_mocks(monkeypatch, assets: list[_FakeAsset], logger: _FakeLogger) -> None:
+    monkeypatch.setattr(sync, "validate_target_dir", lambda destination: None)
+    monkeypatch.setattr(sync, "setup_logging", lambda app_log_file, verbose: logger)
+    monkeypatch.setattr(sync, "login_icloud", lambda username, password, logger: object())
+    monkeypatch.setattr(
+        sync,
+        "iter_assets",
+        lambda api, after, skip_videos, include_missing_created_at, on_scan: iter(assets),
+    )
+    monkeypatch.setattr(
+        sync,
+        "download_asset",
+        lambda asset, output_dir, filename: (output_dir / filename, 123),
+    )
+
+
+def test_run_sync_does_not_move_cursor_when_only_future_dates(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    logger = _FakeLogger()
+    assets = [
+        _FakeAsset(
+            asset_id="future-1",
+            filename="IMG_FUTURE.HEIC",
+            created=dt.datetime(2100, 1, 1, tzinfo=dt.timezone.utc),
+        )
+    ]
+    _configure_sync_mocks(monkeypatch, assets, logger)
+
+    target_dir = tmp_path / "dest"
+    db_path = target_dir / ".ipb.sqlite3"
+    exit_code = sync.run_sync(
+        target_dir=target_dir,
+        db_path=db_path,
+        dry_run=False,
+        limit=None,
+        verbose=False,
+        after=None,
+        skip_videos=False,
+        missing_created_at_strategy="skip",
+        username="me@example.com",
+        password="secret",
+        app_log_file=tmp_path / "ipb.log",
+    )
+
+    assert exit_code == 0
+    conn = init_db(db_path)
+    try:
+        assert get_meta(conn, "last_downloaded_created_at") is None
+    finally:
+        conn.close()
+
+    assert any("future timestamp" in warning for warning in logger.warnings)
+    assert any("Cursor unchanged" in warning for warning in logger.warnings)
+
+
+def test_run_sync_cursor_uses_latest_non_future_date(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    logger = _FakeLogger()
+    assets = [
+        _FakeAsset(
+            asset_id="future-1",
+            filename="IMG_FUTURE.HEIC",
+            created=dt.datetime(2100, 1, 1, tzinfo=dt.timezone.utc),
+        ),
+        _FakeAsset(
+            asset_id="normal-1",
+            filename="IMG_NORMAL.HEIC",
+            created=dt.datetime(2025, 12, 31, 12, 30, tzinfo=dt.timezone.utc),
+        ),
+    ]
+    _configure_sync_mocks(monkeypatch, assets, logger)
+
+    target_dir = tmp_path / "dest"
+    db_path = target_dir / ".ipb.sqlite3"
+    exit_code = sync.run_sync(
+        target_dir=target_dir,
+        db_path=db_path,
+        dry_run=False,
+        limit=None,
+        verbose=False,
+        after=None,
+        skip_videos=False,
+        missing_created_at_strategy="skip",
+        username="me@example.com",
+        password="secret",
+        app_log_file=tmp_path / "ipb.log",
+    )
+
+    assert exit_code == 0
+    conn = init_db(db_path)
+    try:
+        assert (
+            get_meta(conn, "last_downloaded_created_at")
+            == "2025-12-31T12:30:00+00:00"
+        )
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- prevent `last_downloaded_created_at` from being advanced by future-dated asset timestamps
- keep cursor unchanged (with warning) when a sync run downloads only future-dated assets
- add regression tests for future-only and mixed future/non-future download scenarios
- bump version to `1.2.4` and add changelog notes

## Verification
- python3 -m pytest -q