### PR TITLE
fix(sync): restore incremental scan correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project are documented in this file.
 
+## [1.2.5] - 2026-04-11
+
+### Fixed
+
+- Fixed incremental scan regression where descending album optimization could stop scanning too early and miss newer candidates.
+- Fixed datetime comparison errors when mixing naive (`--after YYYY-MM-DD`) and timezone-aware iCloud timestamps.
+
+### Tests
+
+- Added regression coverage for mixed timezone-aware/naive cursor comparisons and descending-order scan behavior.
+
 ## [1.2.4] - 2026-04-06
 
 ### Fixed

--- a/icloud_photo_backup/sync.py
+++ b/icloud_photo_backup/sync.py
@@ -37,6 +37,13 @@ VIDEO_EXTENSIONS = {
 SPINNER_FRAMES = ("|", "/", "-", "\\")
 
 
+def to_utc_datetime(value: dt.datetime) -> dt.datetime:
+    """Normalize datetimes to UTC for safe comparisons."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.timezone.utc)
+    return value.astimezone(dt.timezone.utc)
+
+
 def format_bytes(num_bytes: int) -> str:
     """Return a human-readable byte size string."""
     if num_bytes < 1024:
@@ -262,25 +269,24 @@ def iter_assets(
         raise RuntimeError("iCloud Photos is unavailable for this account.")
 
     album = photos.all
-    descending = album_is_descending(album)
     scanned_count = 0
     matched_count = 0
+    after_utc = to_utc_datetime(after) if after is not None else None
 
     for asset in album:
         scanned_count += 1
         created_at = parse_created_at(getattr(asset, "created", None))
+        created_at_utc = to_utc_datetime(created_at) if created_at is not None else None
 
-        if after is not None:
-            if created_at is None:
+        if after_utc is not None:
+            if created_at_utc is None:
                 if not include_missing_created_at:
                     if on_scan is not None:
                         on_scan(scanned_count, matched_count)
                     continue
-            elif created_at < after:
+            elif created_at_utc < after_utc:
                 if on_scan is not None:
                     on_scan(scanned_count, matched_count)
-                if descending and not include_missing_created_at:
-                    break
                 continue
 
         filename = get_asset_filename(asset)
@@ -540,21 +546,22 @@ def run_sync(
                 )
                 downloaded_count += 1
                 if created_at is not None:
+                    created_at_utc = to_utc_datetime(created_at)
                     now = dt.datetime.now(dt.timezone.utc)
-                    if created_at > now:
+                    if created_at_utc > now:
                         saw_future_created_at = True
                         logger.warning(
                             "Skipping asset with future timestamp: %s > %s (%s)",
-                            created_at,
+                            created_at_utc,
                             now,
                             filename,
                         )
                     elif latest_created_at_downloaded is None:
-                        latest_created_at_downloaded = created_at
+                        latest_created_at_downloaded = created_at_utc
                     else:
                         latest_created_at_downloaded = max(
                             latest_created_at_downloaded,
-                            created_at,
+                            created_at_utc,
                         )
                 downloaded_bytes += size
                 if media_type == "video":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "icloud-photo-backup"
-version = "1.2.4"
+version = "1.2.5"
 description = "Incremental iCloud Photos backup CLI for macOS"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_sync_progress.py
+++ b/tests/test_sync_progress.py
@@ -148,7 +148,7 @@ def test_iter_assets_can_include_missing_created_at_with_flag() -> None:
     assert [asset.filename for asset in result] == ["dated.jpg", "unknown.jpg"]
 
 
-def test_iter_assets_breaks_early_for_descending_album() -> None:
+def test_iter_assets_does_not_break_early_for_descending_album() -> None:
     assets = [
         _FakeAsset(dt.datetime(2026, 3, 2, 9, 0, 0), "recent.jpg"),
         _FakeAsset(dt.datetime(2026, 3, 1, 9, 0, 0), "older.jpg"),
@@ -163,4 +163,21 @@ def test_iter_assets_breaks_early_for_descending_album() -> None:
             skip_videos=False,
         )
     )
-    assert [asset.filename for asset in result] == ["recent.jpg"]
+    assert [asset.filename for asset in result] == ["recent.jpg", "should-not-be-reached.jpg"]
+
+
+def test_iter_assets_handles_mixed_timezone_awareness() -> None:
+    assets = [
+        _FakeAsset(dt.datetime(2026, 3, 2, 10, 0, 0, tzinfo=dt.timezone.utc), "new.jpg"),
+        _FakeAsset(dt.datetime(2026, 3, 1, 10, 0, 0, tzinfo=dt.timezone.utc), "old.jpg"),
+    ]
+    api = _FakeApi(_FakeAlbum(assets, "ASCENDING"))
+
+    result = list(
+        sync.iter_assets(
+            api,
+            after=dt.datetime(2026, 3, 2, 0, 0, 0),
+            skip_videos=False,
+        )
+    )
+    assert [asset.filename for asset in result] == ["new.jpg"]


### PR DESCRIPTION
## Summary
- fix incremental scan filtering so descending album iteration no longer breaks early and misses newer assets
- normalize cursor and asset datetimes to UTC before comparing, preventing naive/aware datetime comparison crashes
- bump version to `1.2.5` and document the regression fix in changelog

## Verification
- python3 -m pytest -q